### PR TITLE
CVE-2018-12538

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -1,0 +1,57 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+
+    <server>
+      <id>repo.jenkins-ci.org</id>
+      <configuration>
+        <httpConfiguration>
+          <all>
+            <connectionTimeout>5000</connectionTimeout>
+            <readTimeout>5000</readTimeout>
+          </all>
+        </httpConfiguration>
+      </configuration>
+    </server>
+
+    <server>
+      <id>central</id>
+      <configuration>
+        <httpConfiguration>
+          <all>
+            <connectionTimeout>5000</connectionTimeout>
+            <readTimeout>5000</readTimeout>
+          </all>
+        </httpConfiguration>
+      </configuration>
+    </server>
+
+    <server>
+      <id>sonatype</id>
+      <configuration>
+        <httpConfiguration>
+          <all>
+            <connectionTimeout>5000</connectionTimeout>
+            <readTimeout>5000</readTimeout>
+          </all>
+        </httpConfiguration>
+      </configuration>
+    </server>
+
+    <server>
+      <id>sonatype-apache</id>
+      <configuration>
+        <httpConfiguration>
+          <all>
+            <connectionTimeout>5000</connectionTimeout>
+            <readTimeout>5000</readTimeout>
+          </all>
+        </httpConfiguration>
+      </configuration>
+    </server>
+
+  </servers>
+</settings>
+

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,12 @@
         <relativePath/>
     </parent>
 
-    <groupId>com.amadeus.plugins</groupId>
-    <artifactId>pipeline-unbreakable-build-plugin</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <groupId>com.amadeus.jenkins.plugins</groupId>
+    <artifactId>unbreakable-branches-jenkins</artifactId>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
-    <name>Swb Pipeline Unbreakable Build Plugin</name>
+    <name>Unbreakable Branches Jenkins Plugin</name>
 
     <organization>
         <name>Amadeus</name>
@@ -65,7 +65,7 @@
 
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.136</jenkins.version>
+        <jenkins.version>2.89</jenkins.version>
         <java.level>8</java.level>
         <workflow.aggregator.version>2.5</workflow.aggregator.version>
         <httpclient.version>4.5.5-2.1</httpclient.version>
@@ -110,14 +110,21 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.5.v20170502</version>
+            <version>9.4.11.v20180605</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>9.4.5.v20170502</version>
+            <version>9.4.11.v20180605</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-security</artifactId>
+            <version>9.4.11.v20180605</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
moderate severity
Vulnerable versions: >= 9.4.0, < 9.4.11.v20180605
Patched version: 9.4.11.v20180605

In Eclipse Jetty versions 9.4.0 through 9.4.8, when using the optional
Jetty provided FileSessionDataStore for persistent storage of
HttpSession details, it is possible for a malicious user to
access/hijack other HttpSessions and even delete unmatched HttpSessions
present in the FileSystem's storage for the FileSessionDataStore.